### PR TITLE
Integrate edit profile modal functionality

### DIFF
--- a/frontend/app/(tabs)/index.tsx
+++ b/frontend/app/(tabs)/index.tsx
@@ -24,7 +24,7 @@ const HomeScreen: FC = () => {
   useUserSync();
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
       <View className="flex-row justify-between items-center px-4 py-3 border-b border-gray-100">
         <Ionicons name="logo-twitter" size={24} color="#1DA1F2" />
         <Text className="text-xl font-bold text-gray-900">Home</Text>

--- a/frontend/app/(tabs)/profile.tsx
+++ b/frontend/app/(tabs)/profile.tsx
@@ -16,6 +16,8 @@ import PostsList from "@/components/PostsList";
 import ProfileHeader from "@/components/ProfileHeader";
 import ProfileInfo from "@/components/ProfileInfo";
 import ProfileAvatarBanner from "@/components/ProfileAvatarBanner";
+import { useProfile } from "@/hooks/useProfile";
+import EditProfileModal from "@/components/EditProfileModal";
 
 const ProfileScreen = () => {
   const { currentUser, isLoading } = useCurrentUser();
@@ -27,6 +29,17 @@ const ProfileScreen = () => {
     isLoading: isRefetching,
   } = usePosts(currentUser.username);
 
+  const {
+    isEditModalVisible,
+    openEditModal,
+    closeEditModal,
+    formData,
+    saveProfile,
+    updateFormField,
+    isUpdating,
+    refetch: refetchProfile,
+  } = useProfile();
+
   if (isLoading) {
     return (
       <View className="flex-1 items-center justify-center bg-white">
@@ -36,7 +49,7 @@ const ProfileScreen = () => {
   }
 
   return (
-    <SafeAreaView className="flex-1 bg-white">
+    <SafeAreaView className="flex-1 bg-white" edges={["top"]}>
       {/* HEADER */}
       <ProfileHeader
         firstName={currentUser.firstName}
@@ -51,7 +64,11 @@ const ProfileScreen = () => {
         refreshControl={
           <RefreshControl
             refreshing={isRefetching}
-            onRefresh={refetchPosts}
+            onRefresh={() => {
+              refetchPosts();
+              refetchProfile();
+            }}
+            colors={["#1DA1F2"]}
             tintColor={"#1DA1F2"}
           />
         }
@@ -63,9 +80,7 @@ const ProfileScreen = () => {
             "https://images.unsplash.com/photo-1530982011887-3cc11cc85693?q=80&w=3132&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
           }
           profilePicture={currentUser.profilePicture}
-          onEditProfile={() => {
-            // TODO: Implement edit profile functionality
-          }}
+          onEditProfile={() => openEditModal()}
         />
 
         <View className="px-4 pb-4 border-b border-gray-100">
@@ -83,6 +98,14 @@ const ProfileScreen = () => {
 
         <PostsList username={currentUser.username} />
       </ScrollView>
+      <EditProfileModal
+        isVisible={isEditModalVisible}
+        onClose={closeEditModal}
+        formData={formData}
+        updateFormField={updateFormField}
+        saveProfile={saveProfile}
+        isUpdating={isUpdating}
+      />
     </SafeAreaView>
   );
 };

--- a/frontend/components/EditProfileModal.tsx
+++ b/frontend/components/EditProfileModal.tsx
@@ -1,0 +1,110 @@
+import {
+  View,
+  Text,
+  Modal,
+  TouchableOpacity,
+  ActivityIndicator,
+  ScrollView,
+  TextInput,
+} from "react-native";
+import React from "react";
+import { EditProfileProps } from "@/hooks/useProfile";
+
+const formFields = [
+  {
+    key: "firstName",
+    label: "First Name",
+    placeholder: "Your first name",
+    multiline: false,
+  },
+  {
+    key: "lastName",
+    label: "Last Name",
+    placeholder: "Your last name",
+    multiline: false,
+  },
+  {
+    key: "bio",
+    label: "Bio",
+    placeholder: "Tell us about yourself",
+    multiline: true,
+  },
+  {
+    key: "location",
+    label: "Location",
+    placeholder: "Where are you located?",
+    multiline: false,
+  },
+] as const;
+
+interface EditProfileModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+  formData: EditProfileProps;
+  updateFormField: (field: keyof EditProfileProps, value: string) => void;
+  saveProfile: () => void;
+  isUpdating: boolean;
+}
+
+const EditProfileModal = ({
+  isVisible,
+  onClose,
+  formData,
+  updateFormField,
+  saveProfile,
+  isUpdating,
+}: EditProfileModalProps) => {
+  return (
+    <Modal
+      visible={isVisible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+    >
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-gray-100">
+        <TouchableOpacity onPress={onClose}>
+          <Text className="text-blue-500 text-lg">Cancel</Text>
+        </TouchableOpacity>
+
+        <Text className="text-lg font-semibold">Edit Profile</Text>
+
+        <TouchableOpacity
+          onPress={() => {
+            saveProfile();
+            onClose();
+          }}
+          disabled={isUpdating}
+          className={`${isUpdating ? "opacity-50" : ""}`}
+        >
+          {isUpdating ? (
+            <ActivityIndicator size={"small"} color={"#1DA1F2"} />
+          ) : (
+            <Text className="text-blue-500 text-lg font-semibold">Save</Text>
+          )}
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView className="flex-1 px-4 py-6">
+        <View className="flex-col gap-3 space-y-4">
+          {formFields.map(({ key, label, placeholder, multiline }) => (
+            <View key={key}>
+              <Text className="text-gray-500 text-sm mb-1">{label}</Text>
+              <TextInput
+                value={formData[key]}
+                onChangeText={(text) =>
+                  updateFormField(key as keyof EditProfileProps, text)
+                }
+                className="border border-gray-200 rounded-lg p-3 text-base"
+                placeholder={placeholder}
+                multiline={multiline}
+                numberOfLines={multiline ? 3 : 1}
+                textAlignVertical={multiline ? "top" : "center"}
+              />
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </Modal>
+  );
+};
+
+export default EditProfileModal;

--- a/frontend/components/EditProfileModal.tsx
+++ b/frontend/components/EditProfileModal.tsx
@@ -54,6 +54,10 @@ const EditProfileModal = ({
   saveProfile,
   isUpdating,
 }: EditProfileModalProps) => {
+  const handleSave = React.useCallback(() => {
+    saveProfile();
+  }, [saveProfile]);
+
   return (
     <Modal
       visible={isVisible}
@@ -68,10 +72,7 @@ const EditProfileModal = ({
         <Text className="text-lg font-semibold">Edit Profile</Text>
 
         <TouchableOpacity
-          onPress={() => {
-            saveProfile();
-            onClose();
-          }}
+          onPress={handleSave}
           disabled={isUpdating}
           className={`${isUpdating ? "opacity-50" : ""}`}
         >

--- a/frontend/components/ProfileInfo.tsx
+++ b/frontend/components/ProfileInfo.tsx
@@ -50,7 +50,7 @@ const ProfileInfo: React.FC<ProfileInfoProps> = ({
       />
       <Text className="text-gray-500 ml-2">Joined {createdAt}</Text>
     </View>
-    <View className="flex-row ml-[2px]">
+    <View className="flex-row">
       <Text className="text-gray-900 mr-3">
         <Text className="font-bold">{followingCount}</Text>
         <Text className="text-gray-500"> Following</Text>

--- a/frontend/hooks/useProfile.ts
+++ b/frontend/hooks/useProfile.ts
@@ -51,8 +51,8 @@ export const useProfile = () => {
         bio: currentUser.bio || "",
         location: currentUser.location || "",
       });
+      setIsEditModalVisible(true);
     }
-    setIsEditModalVisible(true);
   }, [currentUser]);
 
   const closeEditModal = useCallback(() => setIsEditModalVisible(false), []);

--- a/frontend/hooks/useProfile.ts
+++ b/frontend/hooks/useProfile.ts
@@ -1,0 +1,102 @@
+import { useApiClient, userApiClient } from "@/utils/api";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState, useCallback, useMemo } from "react";
+import { useCurrentUser } from "./useCurrentUser";
+import { Alert } from "react-native";
+
+export interface EditProfileProps {
+  firstName: string;
+  lastName: string;
+  bio: string;
+  location: string;
+}
+
+export const useProfile = () => {
+  const api = useApiClient();
+
+  const queryClient = useQueryClient();
+
+  const [isEditModalVisible, setIsEditModalVisible] = useState(false);
+
+  const [formData, setFormData] = useState<EditProfileProps>({
+    firstName: "",
+    lastName: "",
+    bio: "",
+    location: "",
+  });
+
+  const { currentUser } = useCurrentUser();
+
+  const updateProfileMutation = useMutation({
+    mutationFn: (profileData: EditProfileProps) =>
+      userApiClient.updateProfile(api, profileData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["authUser"] });
+      setIsEditModalVisible(false);
+      Alert.alert("Success", "Profile updated successfully!");
+    },
+    onError: (error: any) => {
+      Alert.alert(
+        "Failed to update profile",
+        error?.message || "Please try again."
+      );
+    },
+  });
+
+  const openEditModal = useCallback(() => {
+    if (currentUser) {
+      setFormData({
+        firstName: currentUser.firstName || "",
+        lastName: currentUser.lastName || "",
+        bio: currentUser.bio || "",
+        location: currentUser.location || "",
+      });
+    }
+    setIsEditModalVisible(true);
+  }, [currentUser]);
+
+  const closeEditModal = useCallback(() => setIsEditModalVisible(false), []);
+
+  const saveProfile = useCallback(
+    () => updateProfileMutation.mutate(formData),
+    [formData, updateProfileMutation]
+  );
+
+  const updateFormField = useCallback(
+    <K extends keyof EditProfileProps>(field: K, value: string) => {
+      setFormData((prevData) => ({
+        ...prevData,
+        [field]: value,
+      }));
+    },
+    []
+  );
+
+  const refetch = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: ["authUser"] }),
+    [queryClient]
+  );
+
+  return useMemo(
+    () => ({
+      isEditModalVisible,
+      formData,
+      openEditModal,
+      closeEditModal,
+      saveProfile,
+      updateFormField,
+      isUpdating: updateProfileMutation.isPending,
+      refetch,
+    }),
+    [
+      isEditModalVisible,
+      formData,
+      openEditModal,
+      closeEditModal,
+      saveProfile,
+      updateFormField,
+      updateProfileMutation.isPending,
+      refetch,
+    ]
+  );
+};


### PR DESCRIPTION
Add an edit profile modal to allow users to update their profile information, including first name, last name, bio, and location. The modal integrates with the existing user data and provides feedback upon successful updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile editing functionality with a new modal interface, allowing users to update their first name, last name, bio, and location.
  * Introduced pull-to-refresh that reloads both posts and profile data.

* **Improvements**
  * Adjusted safe area handling to only apply padding at the top edge on relevant screens.
  * Refined profile info layout for improved visual alignment.

* **User Interface**
  * Added a dedicated modal for editing profile details with a user-friendly form and loading indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->